### PR TITLE
New fetch command, prints out manifest

### DIFF
--- a/src/commands/addons/admin/manifest/fetch.ts
+++ b/src/commands/addons/admin/manifest/fetch.ts
@@ -1,0 +1,43 @@
+// heroku-cli
+import {Command, flags} from '@heroku-cli/command'
+import * as Heroku from '@heroku-cli/schema'
+import color from '@heroku-cli/color'
+
+// other packages
+import cli from 'cli-ux'
+
+export default class Fetch extends Command {
+  static description = 'fetch a manifest for a given slug'
+
+  static examples = [ `$ heroku addons:admin:fetch slowdb
+{...`, ]
+
+  static flags = {
+    help: flags.help({char: 'h'}),
+  }
+
+  static args = [{name: 'slug'}]
+
+  async run() {
+    const {args, flags} = this.parse(Fetch)
+
+    let {body: account} = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
+    let email = account.email
+
+    let defaultOptions = {
+      headers: {
+        authorization: `Basic ${Buffer.from(email + ':' + this.heroku.auth).toString('base64')}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'User-Agent': 'kensa future'
+      }
+    }
+    const slug = args.slug
+    const host = process.env.HEROKU_ADDONS_HOST || 'https://addons.heroku.com'
+
+    cli.action.start(`Fetching add-on manifest for ${slug}`)
+
+    const {body} = await this.heroku.get<any>(`${host}/provider/addons/${slug}`, defaultOptions)
+    this.log(body)
+  }
+}

--- a/src/commands/addons/admin/manifest/generate.ts
+++ b/src/commands/addons/admin/manifest/generate.ts
@@ -13,13 +13,13 @@ import generateManifest from '../../../../utils/manifest'
 export default class Generate extends Command {
   static description = 'generate a manifest template'
 
-  static examples = [ `$ oclif-example addons:admin:create_manifest
+  static examples = [ `$ oclif-example addons:admin:generate
 The file has been saved!`, ]
 
   async run() {
     const {body: account} = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
     if (!account) {
-      this.error(color.red('Please login with Heroku creditials using `heroku login`.'))
+      this.error(color.red('Please login with Heroku credentials using `heroku login`.'))
     }
 
     const manifest = generateManifest({}); // this function takes in an object see utils/manifest

--- a/test/commands/addons/admin/manifest/fetch.test.ts
+++ b/test/commands/addons/admin/manifest/fetch.test.ts
@@ -1,0 +1,17 @@
+import {expect, test} from '@oclif/test'
+
+describe('fetch', () => {
+  test
+  .stdout()
+  .command(['fetch'])
+  .it('runs hello', ctx => {
+    expect(ctx.stdout).to.contain('hello world')
+  })
+
+  test
+  .stdout()
+  .command(['fetch', '--name', 'jeff'])
+  .it('runs hello --name jeff', ctx => {
+    expect(ctx.stdout).to.contain('hello jeff')
+  })
+})


### PR DESCRIPTION
Some day this will do more, but for now, just print out the manifest requested.

Demonstrates auth with addons.h.c, which we'll probably re-use later by refactoring into an util function.