### PR TITLE
Use V3 endpoints rather than /provider/addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "fs-extra": "^7.0.0",
     "inquirer": "^6.0.0",
     "jsdiff": "^1.1.1",
+    "lodash": "^4.17.11",
     "randomstring": "^1.1.5",
     "tslib": "^1"
   },

--- a/src/admin-base.ts
+++ b/src/admin-base.ts
@@ -1,8 +1,8 @@
 import color from '@heroku-cli/color'
 import {APIClient, Command} from '@heroku-cli/command'
 import cli from 'cli-ux'
-import * as url from 'url'
 import * as _ from 'lodash'
+import * as url from 'url'
 
 export default abstract class AdminBase extends Command {
   get addons() {
@@ -26,7 +26,7 @@ export default abstract class AdminBase extends Command {
         cli.action.stop()
 
         return body.contents
-      } catch(err) {
+      } catch (err) {
         const error = _.get(err, 'body.error')
         if (error) {
           this.error(error)
@@ -49,10 +49,10 @@ export default abstract class AdminBase extends Command {
         cli.action.stop()
 
         return body.contents
-      } catch(err) {
+      } catch (err) {
         const baseErrors = _.get(err, 'body.error.base')
         if (baseErrors) {
-          this.error(baseErrors.join(", "))
+          this.error(baseErrors.join(', '))
         }
         const error = _.get(err, 'body.error')
         if (error) {

--- a/test/admin-base.test.ts
+++ b/test/admin-base.test.ts
@@ -40,7 +40,7 @@ describe('AdminBase', () => {
     .catch(err => {
       expect(err.message).to.eq('A list of supported regions is required, see https://devcenter.heroku.com/articles/add-on-manifest, Something else failed')
     })
-    .it('throws an error')
+    .it('push throws an error when 422')
 
   test
     .nock(host, (api: any) => api
@@ -51,7 +51,7 @@ describe('AdminBase', () => {
     )
     .do(async () => cmd.addons.push({id: 'slug'}))
     .catch(err => { expect(err.message).to.eq('Forbidden') })
-    .it('throws an error')
+    .it('push throws an error when 401')
 
   test
     .nock(host, (api: any) => api
@@ -62,7 +62,7 @@ describe('AdminBase', () => {
     )
     .do(async () => cmd.addons.pull('slug'))
     .catch(err => { expect(err.message).to.eq('Forbidden') })
-    .it('throws an error')
+    .it('pull throws an error when 401')
 
   test
     .nock(host, (api: any) => api

--- a/test/admin-base.test.ts
+++ b/test/admin-base.test.ts
@@ -1,5 +1,6 @@
 import {Config} from '@oclif/config'
-import {expect, test} from '@oclif/test'
+import {expect} from '@oclif/test'
+import {test, host} from './utils/test'
 import * as path from 'path'
 
 import AdminBase from '../src/admin-base'
@@ -13,19 +14,61 @@ const cmd = new Test([], config)
 
 describe('AdminBase', () => {
   test
-    .it('#addons', () => {
-      expect(cmd.addons.pull).to.be.a('function')
-      expect(cmd.addons.push).to.be.a('function')
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/slug/current_manifest')
+      .reply(200, {contents: {id: 'slug'}})
+    )
+    .it('returns the manifest contents', async () => {
+      const manifest:any = await cmd.addons.pull('slug')
+      expect(manifest).to.deep.equal({id: 'slug'})
     })
 
   test
-    .nock('https://api.heroku.com', (api: any) => api
-      .get('/account')
-      .reply(200, {email: 'codey@salesforce.com'})
+    .nock(host, (api: any) => api
+      .post('/api/v3/addons/slug/manifests', {contents: {id: 'slug'}})
+      .reply(422, {
+        error: {
+          base: [
+            'A list of supported regions is required, see https://devcenter.heroku.com/articles/add-on-manifest',
+            'Something else failed'
+          ]
+        }
+      })
     )
-    .it('(private) #email', async () => {
-      // escape compliler errors of private method
-      const email = await (cmd as any).email()
-      expect(email).to.eq('codey@salesforce.com')
+    .do(async () => await cmd.addons.push({id: 'slug'}))
+    .catch(err => { expect(err.message).to.eq(`A list of supported regions is required, see https://devcenter.heroku.com/articles/add-on-manifest, Something else failed`)
+    })
+    .it('throws an error')
+
+  test
+    .nock(host, (api: any) => api
+      .post('/api/v3/addons/slug/manifests', {contents: {id: 'slug'}})
+      .reply(401, {
+        error: 'Forbidden',
+      })
+    )
+    .do(async () => await cmd.addons.push({id: 'slug'}))
+    .catch(err => { expect(err.message).to.eq('Forbidden') })
+    .it('throws an error')
+
+  test
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/slug/current_manifest')
+      .reply(401, {
+        error: 'Forbidden',
+      })
+    )
+    .do(async () => await cmd.addons.pull('slug'))
+    .catch(err => { expect(err.message).to.eq('Forbidden') })
+    .it('throws an error')
+
+  test
+    .nock(host, (api: any) => api
+      .post('/api/v3/addons/slug/manifests', {contents: {id: 'slug'}})
+      .reply(200, {contents: {id: 'slug', '$base': 1234}})
+    )
+    .it('pushes the manifest contents', async () => {
+      const manifest:any = await cmd.addons.push({id: 'slug'})
+      expect(manifest).to.deep.equal({id: 'slug', '$base': 1234})
     })
 })

--- a/test/admin-base.test.ts
+++ b/test/admin-base.test.ts
@@ -1,9 +1,10 @@
 import {Config} from '@oclif/config'
 import {expect} from '@oclif/test'
-import {test, host} from './utils/test'
 import * as path from 'path'
 
 import AdminBase from '../src/admin-base'
+
+import {host, test} from './utils/test'
 
 const root = path.resolve(__dirname, '../package.json')
 const config = new Config({root})
@@ -19,7 +20,7 @@ describe('AdminBase', () => {
       .reply(200, {contents: {id: 'slug'}})
     )
     .it('returns the manifest contents', async () => {
-      const manifest:any = await cmd.addons.pull('slug')
+      const manifest: any = await cmd.addons.pull('slug')
       expect(manifest).to.deep.equal({id: 'slug'})
     })
 
@@ -35,8 +36,9 @@ describe('AdminBase', () => {
         }
       })
     )
-    .do(async () => await cmd.addons.push({id: 'slug'}))
-    .catch(err => { expect(err.message).to.eq(`A list of supported regions is required, see https://devcenter.heroku.com/articles/add-on-manifest, Something else failed`)
+    .do(async () => cmd.addons.push({id: 'slug'}))
+    .catch(err => {
+      expect(err.message).to.eq('A list of supported regions is required, see https://devcenter.heroku.com/articles/add-on-manifest, Something else failed')
     })
     .it('throws an error')
 
@@ -47,7 +49,7 @@ describe('AdminBase', () => {
         error: 'Forbidden',
       })
     )
-    .do(async () => await cmd.addons.push({id: 'slug'}))
+    .do(async () => cmd.addons.push({id: 'slug'}))
     .catch(err => { expect(err.message).to.eq('Forbidden') })
     .it('throws an error')
 
@@ -58,17 +60,17 @@ describe('AdminBase', () => {
         error: 'Forbidden',
       })
     )
-    .do(async () => await cmd.addons.pull('slug'))
+    .do(async () => cmd.addons.pull('slug'))
     .catch(err => { expect(err.message).to.eq('Forbidden') })
     .it('throws an error')
 
   test
     .nock(host, (api: any) => api
       .post('/api/v3/addons/slug/manifests', {contents: {id: 'slug'}})
-      .reply(200, {contents: {id: 'slug', '$base': 1234}})
+      .reply(200, {contents: {id: 'slug', $base: 1234}})
     )
     .it('pushes the manifest contents', async () => {
-      const manifest:any = await cmd.addons.push({id: 'slug'})
-      expect(manifest).to.deep.equal({id: 'slug', '$base': 1234})
+      const manifest: any = await cmd.addons.push({id: 'slug'})
+      expect(manifest).to.deep.equal({id: 'slug', $base: 1234})
     })
 })

--- a/test/commands/addons/admin/manifest/diff.test.ts
+++ b/test/commands/addons/admin/manifest/diff.test.ts
@@ -25,8 +25,8 @@ const testManifest = {
 describe('addons:admin:manifest:diff', () => {
   test
     .nock(host, (api: any) => api
-      .get('/provider/addons/testing-123')
-      .reply(200, manifest)
+      .get('/api/v3/addons/testing-123/current_manifest')
+      .reply(200, {contents: manifest})
     )
     .stdout()
     .stderr()
@@ -37,8 +37,8 @@ describe('addons:admin:manifest:diff', () => {
 
   test
     .nock(host, (api: any) => api
-      .get('/provider/addons/testing-123')
-      .reply(200, manifest)
+      .get('/api/v3/addons/testing-123/current_manifest')
+      .reply(200, {contents: manifest})
     )
     .stdout()
     .stderr()
@@ -57,8 +57,8 @@ describe('addons:admin:manifest:diff', () => {
 
   test
     .nock(host, (api: any) => {
-      api.get('/provider/addons/testing-123')
-        .reply(200, {body: testManifest})
+      api.get('/api/v3/addons/testing-123/current_manifest')
+        .reply(200, {contents: testManifest})
     })
     .stdout()
     .stderr()
@@ -69,7 +69,7 @@ describe('addons:admin:manifest:diff', () => {
 
   test
     .nock(host, (api: any) => {
-      api.get('/provider/addons/testing-123')
+      api.get('/api/v3/addons/testing-123/current_manifest')
         .replyWithError('test')
     })
     .stdout()

--- a/test/commands/addons/admin/manifest/pull.test.ts
+++ b/test/commands/addons/admin/manifest/pull.test.ts
@@ -7,8 +7,8 @@ describe('addons:admin:manifest:pull', () => {
     .stdout()
     .stderr()
     .nock(host, (api: any) => api
-      .get('/provider/addons/testing-123')
-      .reply(200, manifest)
+      .get('/api/v3/addons/testing-123/current_manifest')
+      .reply(200, {contents: manifest})
     )
 
   pullTest
@@ -27,7 +27,7 @@ describe('addons:admin:manifest:pull', () => {
     .stdout()
     .stderr()
     .nock(host, (api: any) => api
-      .get('/provider/addons/fakeslug')
+      .get('/api/v3/addons/fakeslug/current_manifest')
       .replyWithError(400)
     )
     .command(['addons:admin:manifest:pull', 'fakeslug'])

--- a/test/commands/addons/admin/manifest/push.test.ts
+++ b/test/commands/addons/admin/manifest/push.test.ts
@@ -7,8 +7,8 @@ describe('addons:admin:manifest:push', () => {
     .stdout()
     .stderr()
     .nock(host, (api: any) => {
-      api.post('/provider/addons', manifest)
-        .reply(200, manifest)
+      api.post(`/api/v3/addons/${manifest.id}/manifests`, {contents: manifest})
+        .reply(200, {contents: manifest})
     })
     .command(['addons:admin:manifest:push'])
     .it('stdout contains manifest elements', (ctx: any) => {
@@ -19,7 +19,7 @@ describe('addons:admin:manifest:push', () => {
 
   test
     .nock(host, (api: any) => {
-      api.post('/provider/addons', manifest)
+      api.post(`/api/v3/addons/${manifest.id}/manifests`, {contents: manifest})
         .replyWithError(400)
     })
     .stdout()

--- a/test/utils/test.ts
+++ b/test/utils/test.ts
@@ -15,12 +15,6 @@ fsWriteFileSync.throws('write not stubbed')
 fsWriteFileSync.withArgs('addon_manifest.json').returns(undefined)
 
 const test = oTest
-.do(() => {
-  // fancy-test verifies it was called, we just want this stubbed for all tests
-  nock('https://api.heroku.com')
-  .get('/account')
-  .reply(200, {email: 'aman@abc123.com'})
-})
 .stub(fs, 'readFileSync', fsReadFileSync)
 .stub(fs, 'writeFileSync', fsWriteFileSync)
 

--- a/test/utils/test.ts
+++ b/test/utils/test.ts
@@ -1,7 +1,6 @@
 import {test as oTest} from '@oclif/test'
 
 import * as fs from 'fs-extra'
-import * as nock from 'nock'
 import * as sinon from 'sinon'
 
 const manifest = require('./../fixture/addon_manifest')


### PR DESCRIPTION
@RasPhilCo could you review?  I added new endpoints to addons.heroku.com so that we can use the current authentication scheme and to get error responses that are json rather than plain text pretending to be JSON.  Let me know if you have any questions.