### PR TITLE
Add manifests & manifests:info to view history

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Follow the [Developing CLI Plugins](https://devcenter.heroku.com/articles/develo
 * [`heroku addons:admin:manifest:generate`](#heroku-addonsadminmanifestgenerate)
 * [`heroku addons:admin:manifest:pull [SLUG]`](#heroku-addonsadminmanifestpull-slug)
 * [`heroku addons:admin:manifest:push`](#heroku-addonsadminmanifestpush)
-* [`heroku addons:admin:manifests`](#heroku-addonsadminmanifests)
-* [`heroku addons:admin:manifests:info MANIFEST`](#heroku-addonsadminmanifestsinfo-manifest)
+* [`heroku addons:admin:manifests [SLUG]`](#heroku-addonsadminmanifests-slug)
+* [`heroku addons:admin:manifests:info [SLUG]`](#heroku-addonsadminmanifestsinfo-slug)
 * [`heroku addons:admin:open [SLUG]`](#heroku-addonsadminopen-slug)
 
 ## `heroku addons:admin`
@@ -155,30 +155,27 @@ EXAMPLE
 
 _See code: [src/commands/addons/admin/manifest/push.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v1.0.0/src/commands/addons/admin/manifest/push.ts)_
 
-## `heroku addons:admin:manifests`
+## `heroku addons:admin:manifests [SLUG]`
 
 list manifest history
 
 ```
 USAGE
-  $ heroku addons:admin:manifests
-
-OPTIONS
-  -h, --help       show CLI help
+  $ heroku addons:admin:manifests [SLUG]
 ```
 
 _See code: [src/commands/addons/admin/manifests.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v1.0.0/src/commands/addons/admin/manifests.ts)_
 
-## `heroku addons:admin:manifests:info manifest`
+## `heroku addons:admin:manifests:info [SLUG]`
 
 show an individual history manifest
 
 ```
 USAGE
-  $ heroku addons:admin:manifests:info manifest
+  $ heroku addons:admin:manifests:info [SLUG]
 
 OPTIONS
-  -h, --help       show CLI help
+  -m, --manifest=manifest  (required) manifest history id
 ```
 
 _See code: [src/commands/addons/admin/manifests/info.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v1.0.0/src/commands/addons/admin/manifests/info.ts)_

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Follow the [Developing CLI Plugins](https://devcenter.heroku.com/articles/develo
 * [`heroku addons:admin:manifest:generate`](#heroku-addonsadminmanifestgenerate)
 * [`heroku addons:admin:manifest:pull [SLUG]`](#heroku-addonsadminmanifestpull-slug)
 * [`heroku addons:admin:manifest:push`](#heroku-addonsadminmanifestpush)
+* [`heroku addons:admin:manifests`](#heroku-addonsadminmanifests)
+* [`heroku addons:admin:manifests:info MANIFEST`](#heroku-addonsadminmanifestsinfo-manifest)
 * [`heroku addons:admin:open [SLUG]`](#heroku-addonsadminopen-slug)
 
 ## `heroku addons:admin`
@@ -152,6 +154,34 @@ EXAMPLE
 ```
 
 _See code: [src/commands/addons/admin/manifest/push.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v1.0.0/src/commands/addons/admin/manifest/push.ts)_
+
+## `heroku addons:admin:manifests`
+
+show history manifest listing
+
+```
+USAGE
+  $ heroku addons:admin:manifests
+
+OPTIONS
+  -h, --help       show CLI help
+```
+
+_See code: [src/commands/addons/admin/manifests.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v1.0.0/src/commands/addons/admin/manifests.ts)_
+
+## `heroku addons:admin:manifests:info manifest`
+
+show an individual historical manifest
+
+```
+USAGE
+  $ heroku addons:admin:manifests:info manifest
+
+OPTIONS
+  -h, --help       show CLI help
+```
+
+_See code: [src/commands/addons/admin/manifests/info.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v1.0.0/src/commands/addons/admin/manifests/info.ts)_
 
 ## `heroku addons:admin:open [SLUG]`
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ _See code: [src/commands/addons/admin/manifest/push.ts](https://github.com/herok
 
 ## `heroku addons:admin:manifests`
 
-show history manifest listing
+list manifest history
 
 ```
 USAGE
@@ -171,7 +171,7 @@ _See code: [src/commands/addons/admin/manifests.ts](https://github.com/heroku/he
 
 ## `heroku addons:admin:manifests:info manifest`
 
-show an individual historical manifest
+show an individual history manifest
 
 ```
 USAGE

--- a/src/admin-base.ts
+++ b/src/admin-base.ts
@@ -35,6 +35,39 @@ export default abstract class AdminBase extends Command {
       }
     }
 
+    const manifests = async (slug: string) => {
+      try {
+        cli.action.start(`Fetching add-on manifests for ${color.addon(slug)}`)
+        const response = await client.get(`/api/v3/addons/${encodeURIComponent(slug)}/manifests`, options)
+        cli.action.stop()
+
+        return response.body
+      } catch (err) {
+        const error = _.get(err, 'body.error')
+        if (error) {
+          this.error(error)
+        }
+        throw err
+      }
+    }
+
+    const manifest = async (slug: string, uuid: string) => {
+      try {
+        cli.action.start(`Fetching add-on manifest for ${color.addon(slug)}`)
+        const response = await client.get(`/api/v3/addons/${encodeURIComponent(slug)}/manifests/${encodeURIComponent(uuid)}`, options)
+        const body: any = response.body
+        cli.action.stop()
+
+        return body.contents
+      } catch (err) {
+        const error = _.get(err, 'body.error')
+        if (error) {
+          this.error(error)
+        }
+        throw err
+      }
+    }
+
     const push = async (manifest: any) => {
       const requestBody = {contents: manifest}
       let opts = {
@@ -63,6 +96,8 @@ export default abstract class AdminBase extends Command {
     }
 
     return {
+      manifests,
+      manifest,
       pull,
       push
     }

--- a/src/commands/addons/admin/manifest/pull.ts
+++ b/src/commands/addons/admin/manifest/pull.ts
@@ -21,11 +21,7 @@ export default class Pull extends AdminBase {
     const {args} = this.parse(Pull)
 
     // allows users to pull without declaring slug
-    let slug = args.slug
-    if (!args.slug) {
-      slug = ReadManifest.json().id
-    }
-
+    const slug = ReadManifest.slug(args.slug)
     const body = await this.addons.pull(slug)
 
     // writing addon_manifest.json

--- a/src/commands/addons/admin/manifests.ts
+++ b/src/commands/addons/admin/manifests.ts
@@ -7,8 +7,14 @@ import {ReadManifest} from '../../../manifest'
 export default class AddonsAdminManifests extends AdminBase {
   static description = 'list manifest history'
 
+  static args = [{name: 'slug'}]
+
   async run() {
-    let body: any = await this.addons.manifests(ReadManifest.json().id)
+    const {args} = this.parse(AddonsAdminManifests)
+
+    const slug = ReadManifest.slug(args.slug)
+
+    const body: any = await this.addons.manifests(slug)
 
     const columns = [
       {label: 'Manfiest', key: 'id'},

--- a/src/commands/addons/admin/manifests.ts
+++ b/src/commands/addons/admin/manifests.ts
@@ -8,7 +8,7 @@ export default class AddonsAdminManifests extends AdminBase {
 
   async run() {
     const body: any = await this.addons.manifests(ReadManifest.json().id)
-    body.sort((a: any, b: any) => a.created_at < b.created_at)
+    body.sort((a: any, b: any) => Date.parse(a.created_at) < Date.parse(b.created_at))
 
     const columns = [
       {label: 'Manfiest', key: 'id'},

--- a/src/commands/addons/admin/manifests.ts
+++ b/src/commands/addons/admin/manifests.ts
@@ -1,0 +1,20 @@
+import cli from 'cli-ux'
+
+import AdminBase from '../../../admin-base'
+import {ReadManifest} from '../../../manifest'
+
+export default class AddonsAdminManifests extends AdminBase {
+  static description = 'show history manifest listing'
+
+  async run() {
+    const body: any = await this.addons.manifests(ReadManifest.json().id)
+    body.sort((a: any, b: any) => a.created_at < b.created_at)
+
+    const columns = [
+      {label: 'Manfiest', key: 'id'},
+      {label: 'Created At', key: 'created_at'}
+    ]
+
+    cli.table(body, {columns})
+  }
+}

--- a/src/commands/addons/admin/manifests.ts
+++ b/src/commands/addons/admin/manifests.ts
@@ -5,7 +5,7 @@ import AdminBase from '../../../admin-base'
 import {ReadManifest} from '../../../manifest'
 
 export default class AddonsAdminManifests extends AdminBase {
-  static description = 'show history manifest listing'
+  static description = 'list manifest history'
 
   async run() {
     let body: any = await this.addons.manifests(ReadManifest.json().id)

--- a/src/commands/addons/admin/manifests.ts
+++ b/src/commands/addons/admin/manifests.ts
@@ -1,4 +1,5 @@
 import cli from 'cli-ux'
+import * as _ from 'lodash'
 
 import AdminBase from '../../../admin-base'
 import {ReadManifest} from '../../../manifest'
@@ -7,14 +8,13 @@ export default class AddonsAdminManifests extends AdminBase {
   static description = 'show history manifest listing'
 
   async run() {
-    const body: any = await this.addons.manifests(ReadManifest.json().id)
-    body.sort((a: any, b: any) => Date.parse(a.created_at) < Date.parse(b.created_at))
+    let body: any = await this.addons.manifests(ReadManifest.json().id)
 
     const columns = [
       {label: 'Manfiest', key: 'id'},
       {label: 'Created At', key: 'created_at'}
     ]
 
-    cli.table(body, {columns})
+    cli.table(_.orderBy(body, 'created_at', 'desc'), {columns})
   }
 }

--- a/src/commands/addons/admin/manifests/info.ts
+++ b/src/commands/addons/admin/manifests/info.ts
@@ -1,16 +1,26 @@
-import {ReadManifest} from '../../../../manifest'
+import {flags} from '@heroku-cli/command'
 
 import AdminBase from '../../../../admin-base'
+import {ReadManifest} from '../../../../manifest'
 
 export default class AddonsAdminManifestsInfo extends AdminBase {
   static description = 'show an individual history manifest'
 
-  static args = [{name: 'manifest', required: true}]
+  static args = [{name: 'slug'}]
+
+  static flags = {
+    manifest: flags.string({
+      char: 'm',
+      required: true,
+      description: 'manifest history id'
+    })
+  }
 
   async run() {
-    const {args} = this.parse(AddonsAdminManifestsInfo)
+    const {args, flags} = this.parse(AddonsAdminManifestsInfo)
 
-    const body: any = await this.addons.manifest(ReadManifest.json().id, args.manifest)
+    const slug = ReadManifest.slug(args.slug)
+    const body: any = await this.addons.manifest(slug, flags.manifest)
 
     this.log(JSON.stringify(body, null, 2))
   }

--- a/src/commands/addons/admin/manifests/info.ts
+++ b/src/commands/addons/admin/manifests/info.ts
@@ -1,0 +1,17 @@
+import {ReadManifest} from '../../../../manifest'
+
+import AdminBase from '../../../../admin-base'
+
+export default class AddonsAdminManifestsInfo extends AdminBase {
+  static description = 'show an individual history manifest'
+
+  static args = [{name: 'manifest', required: true}]
+
+  async run() {
+    const {args} = this.parse(AddonsAdminManifestsInfo)
+
+    const body: any = await this.addons.manifest(ReadManifest.json().id, args.manifest)
+
+    this.log(JSON.stringify(body, null, 2))
+  }
+}

--- a/src/commands/addons/admin/open.ts
+++ b/src/commands/addons/admin/open.ts
@@ -17,17 +17,7 @@ Opening https://addons-next.heroku.com/addons/testing-123... done`,
   async run() {
     const {args} = this.parse(Open)
 
-    let slug: string
-
-    // check if user gave slug argument
-    if (args.slug) {
-      slug = args.slug
-    } else {
-      // if not use slug specified in manifest
-      cli.action.start('Checking addon_manifest.json')
-      slug = ReadManifest.json().id
-      cli.action.stop()
-    }
+    const slug = ReadManifest.slug(args.slug)
 
     const url = `https://addons-next.heroku.com/addons/${slug}`
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -85,5 +85,13 @@ export const ReadManifest = {
       cli.error('No slug found in manifest')
     }
     return JSON.parse(this.run())
+  },
+
+  slug(slugArg: string): string {
+    // allows users to pull without declaring slug
+    if (slugArg) {
+      return slugArg
+    }
+    return ReadManifest.json().id
   }
 }

--- a/test/admin-base.test.ts
+++ b/test/admin-base.test.ts
@@ -55,6 +55,28 @@ describe('AdminBase', () => {
 
   test
     .nock(host, (api: any) => api
+      .get('/api/v3/addons/slug/manifests')
+      .reply(401, {
+        error: 'Forbidden',
+      })
+    )
+    .do(async () => cmd.addons.manifests('slug'))
+    .catch(err => { expect(err.message).to.eq('Forbidden') })
+    .it('throws an error')
+
+  test
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/slug/manifests/uuid')
+      .reply(401, {
+        error: 'Forbidden',
+      })
+    )
+    .do(async () => cmd.addons.manifest('slug', 'uuid'))
+    .catch(err => { expect(err.message).to.eq('Forbidden') })
+    .it('throws an error')
+
+  test
+    .nock(host, (api: any) => api
       .get('/api/v3/addons/slug/current_manifest')
       .reply(401, {
         error: 'Forbidden',

--- a/test/commands/addons/admin/manifests.test.ts
+++ b/test/commands/addons/admin/manifests.test.ts
@@ -1,0 +1,40 @@
+import {expect} from '@oclif/test'
+
+import test from '../../../utils/test'
+
+const host = process.env.HEROKU_ADDONS_HOST || 'https://addons.heroku.com'
+
+const manifests = [
+  {
+    id: '1a2e3c33-c949-4599-97d9-4ed684c35c2f',
+    created_at: '2017-07-18T21:47:25.894Z',
+    contents: {
+      foo: 'bar'
+    }
+  },
+  {
+    id: '80d90dfb-049f-436b-9543-24cc7b691352',
+    created_at: '2017-07-19T21:47:25.894Z',
+    contents: {
+      biz: 'baz'
+    }
+  }
+]
+
+describe('addons:admin:manifests', () => {
+  test
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/testing-123/manifests')
+      .reply(200, manifests)
+    )
+    .stdout()
+    .command(['addons:admin:manifests'])
+    .it('prints a list of manifests', ctx => {
+      expect(ctx.stdout).to.equal(
+`Manfiest                              Created At
+────────────────────────────────────  ────────────────────────
+80d90dfb-049f-436b-9543-24cc7b691352  2017-07-19T21:47:25.894Z
+1a2e3c33-c949-4599-97d9-4ed684c35c2f  2017-07-18T21:47:25.894Z
+`)
+    })
+})

--- a/test/commands/addons/admin/manifests.test.ts
+++ b/test/commands/addons/admin/manifests.test.ts
@@ -37,4 +37,20 @@ describe('addons:admin:manifests', () => {
 1a2e3c33-c949-4599-97d9-4ed684c35c2f  2017-07-18T21:47:25.894Z
 `)
     })
+
+  test
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/arg-slug/manifests')
+      .reply(200, manifests)
+    )
+    .stdout()
+    .command(['addons:admin:manifests', 'arg-slug'])
+    .it('prints a list of manifests', ctx => {
+      expect(ctx.stdout).to.equal(
+`Manfiest                              Created At
+────────────────────────────────────  ────────────────────────
+80d90dfb-049f-436b-9543-24cc7b691352  2017-07-19T21:47:25.894Z
+1a2e3c33-c949-4599-97d9-4ed684c35c2f  2017-07-18T21:47:25.894Z
+`)
+    })
 })

--- a/test/commands/addons/admin/manifests/info.test.ts
+++ b/test/commands/addons/admin/manifests/info.test.ts
@@ -1,0 +1,30 @@
+import {expect} from '@oclif/test'
+
+import test from '../../../../utils/test'
+
+const host = process.env.HEROKU_ADDONS_HOST || 'https://addons.heroku.com'
+
+const manifest = {
+  id: '1a2e3c33-c949-4599-97d9-4ed684c35c2f',
+  created_at: '2017-07-18T21:47:25.894Z',
+  contents: {
+    foo: 'bar'
+  }
+}
+
+describe('addons:admin:manifests:info', () => {
+  test
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/testing-123/manifests/1a2e3c33-c949-4599-97d9-4ed684c35c2f')
+      .reply(200, manifest)
+    )
+    .stdout()
+    .command(['addons:admin:manifests:info', '1a2e3c33-c949-4599-97d9-4ed684c35c2f'])
+    .it('runs hello', ctx => {
+      expect(ctx.stdout).to.equal(
+`{
+  "foo": "bar"
+}
+`)
+    })
+})

--- a/test/commands/addons/admin/manifests/info.test.ts
+++ b/test/commands/addons/admin/manifests/info.test.ts
@@ -19,8 +19,38 @@ describe('addons:admin:manifests:info', () => {
       .reply(200, manifest)
     )
     .stdout()
-    .command(['addons:admin:manifests:info', '1a2e3c33-c949-4599-97d9-4ed684c35c2f'])
-    .it('runs hello', ctx => {
+    .command(['addons:admin:manifests:info', '-m', '1a2e3c33-c949-4599-97d9-4ed684c35c2f'])
+    .it('prints manifest using -m', ctx => {
+      expect(ctx.stdout).to.equal(
+`{
+  "foo": "bar"
+}
+`)
+    })
+
+  test
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/testing-123/manifests/1a2e3c33-c949-4599-97d9-4ed684c35c2f')
+      .reply(200, manifest)
+    )
+    .stdout()
+    .command(['addons:admin:manifests:info', '--manifest', '1a2e3c33-c949-4599-97d9-4ed684c35c2f'])
+    .it('prints manifest using --manifest', ctx => {
+      expect(ctx.stdout).to.equal(
+`{
+  "foo": "bar"
+}
+`)
+    })
+
+  test
+    .nock(host, (api: any) => api
+      .get('/api/v3/addons/arg-slug/manifests/1a2e3c33-c949-4599-97d9-4ed684c35c2f')
+      .reply(200, manifest)
+    )
+    .stdout()
+    .command(['addons:admin:manifests:info', 'arg-slug', '-m', '1a2e3c33-c949-4599-97d9-4ed684c35c2f'])
+    .it('takes an optional add-on slug argument', ctx => {
       expect(ctx.stdout).to.equal(
 `{
   "foo": "bar"


### PR DESCRIPTION
@mathias could you review?  This adds two new commands to view historical manifests.

```
heroku addons:admin:manifests
heroku addons:admin:manifests:info MANIFEST
```
