### PR TITLE
Add tests for open / generate and refactor

### DIFF
--- a/src/commands/addons/admin/manifest/generate.ts
+++ b/src/commands/addons/admin/manifest/generate.ts
@@ -7,7 +7,7 @@ import {prompt} from 'inquirer'
 import {generate as generateString} from 'randomstring'
 
 import AdminBase from '../../../../admin-base'
-import {GenerateManifest} from '../../../../manifest'
+import {ManifestInterface} from '../../../../manifest'
 
 export default class Generate extends AdminBase {
   static description = 'generate a manifest template'
@@ -37,7 +37,7 @@ The file has been saved!`,
 
     // prompts for manifest
     const promptAnswers = await this.askQuestions(flags, regions)
-    const manifest = GenerateManifest.run(promptAnswers)
+    const manifest = this.generate(promptAnswers)
     await this.writeManifest(manifest)
   }
 
@@ -138,5 +138,42 @@ The file has been saved!`,
       }
       this.log(`The file ${color.green('addon_manifest.json')} has been saved!`)
     })
+  }
+
+  private generate(data: any = {}): ManifestInterface {
+    let manifest: ManifestInterface = {
+      id: 'myaddon',
+      api: {
+        config_vars_prefix: 'MYADDON',
+        config_vars: [
+          'MYADDON_URL'
+        ],
+        password: 'CHANGEME',
+        sso_salt: 'CHANGEME',
+        regions: ['us', 'eu'],
+        requires: [],
+        production: {
+          base_url: 'https://myaddon.com/heroku/resources',
+          sso_url: 'https://myaddon.com/sso/login'
+        },
+        test: {
+          // tslint:disable-next-line:no-http-string
+          base_url: 'http://localhost:4567/heroku/resources',
+          // tslint:disable-next-line:no-http-string
+          sso_url: 'http://localhost:4567/sso/login'
+        },
+        version: '3'
+      },
+      name: 'MyAddon',
+    }
+
+    manifest.id = data.id || manifest.id
+    manifest.api.config_vars_prefix = (data.id ? data.id.toUpperCase() : manifest.api.config_vars_prefix)
+    manifest.api.config_vars = (data.id ? [`${data.id.toUpperCase()}_URL`] : manifest.api.config_vars)
+    manifest.api.password = data.password || manifest.api.password
+    manifest.api.sso_salt = data.sso_salt || manifest.api.sso_salt
+    manifest.api.regions = data.regions || manifest.api.regions
+    manifest.name = data.name || manifest.name
+    return manifest
   }
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -2,7 +2,7 @@ import color from '@heroku-cli/color'
 import cli from 'cli-ux'
 import * as fs from 'fs-extra'
 
-interface ManifestInterface {
+export interface ManifestInterface {
   id: string
   name: string
   api: ManifestAPIInterface
@@ -25,45 +25,6 @@ interface ManifestAPIInterface {
     sso_url: string
   }
   version: string
-}
-
-export const GenerateManifest = {
-  run(data: any = {}): ManifestInterface {
-    let manifest: ManifestInterface = {
-      id: 'myaddon',
-      api: {
-        config_vars_prefix: 'MYADDON',
-        config_vars: [
-          'MYADDON_URL'
-        ],
-        password: 'CHANGEME',
-        sso_salt: 'CHANGEME',
-        regions: ['us', 'eu'],
-        requires: [],
-        production: {
-          base_url: 'https://myaddon.com/heroku/resources',
-          sso_url: 'https://myaddon.com/sso/login'
-        },
-        test: {
-          // tslint:disable-next-line:no-http-string
-          base_url: 'http://localhost:4567/heroku/resources',
-          // tslint:disable-next-line:no-http-string
-          sso_url: 'http://localhost:4567/sso/login'
-        },
-        version: '3'
-      },
-      name: 'MyAddon',
-    }
-
-    manifest.id = data.id || manifest.id
-    manifest.api.config_vars_prefix = (data.id ? data.id.toUpperCase() : manifest.api.config_vars_prefix)
-    manifest.api.config_vars = (data.id ? [`${data.id.toUpperCase()}_URL`] : manifest.api.config_vars)
-    manifest.api.password = data.password || manifest.api.password
-    manifest.api.sso_salt = data.sso_salt || manifest.api.sso_salt
-    manifest.api.regions = data.regions || manifest.api.regions
-    manifest.name = data.name || manifest.name
-    return manifest
-  }
 }
 
 export const ReadManifest = {

--- a/test/commands/addons/admin/manifest/generate.test.ts
+++ b/test/commands/addons/admin/manifest/generate.test.ts
@@ -1,10 +1,185 @@
-import {test} from '@oclif/test'
+import {expect, test} from '@oclif/test'
+import * as fs from 'fs-extra'
+import * as inquirer from 'inquirer'
+import * as randomstring from 'randomstring'
+import * as sinon from 'sinon'
+
+import {manifest} from '../../../../utils/test'
 
 describe('addons:admin:manifest:generate', () => {
-  test
+  const fsWriteFileSync = sinon.stub()
+  fsWriteFileSync.throws('write not stubbed')
+  fsWriteFileSync.withArgs('addon_manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
+
+  const fsWriteFileNotCalled = sinon.stub()
+  fsWriteFileNotCalled.throws('write not stubbed')
+
+  const generateTest = test
     .stdout()
-    // .command(['addons:admin:manifest:generate'])
-    .it('runs hello', _ => {
-      true
+    .stderr()
+    .nock('https://api.heroku.com', (api: any) => api
+      .get('/regions')
+      .reply(200, [{name: 'us'}, {name: 'eu'}])
+    )
+
+  const promptWriteFalse = sinon.stub()
+  promptWriteFalse.returns(Promise.resolve({
+    toGenerate: false,
+    toWrite: false
+  }))
+
+  generateTest
+    .stub(inquirer, 'prompt', promptWriteFalse)
+    .stdout()
+    .command(['addons:admin:manifest:generate'])
+    .catch(() => {})
+    .it('runs', ctx => {
+      expect(ctx.stdout).to.contain('addon_manifest.json will not be created. Have a good day!')
+    })
+
+  const promptGenerateFalse = sinon.stub()
+  promptGenerateFalse.returns(Promise.resolve({
+    toGenerate: false,
+    toWrite: true
+  }))
+
+  const defaultManifest = `{
+  "id": "myaddon",
+  "api": {
+    "config_vars_prefix": "MYADDON",
+    "config_vars": [
+      "MYADDON_URL"
+    ],
+    "password": "CHANGEME",
+    "sso_salt": "CHANGEME",
+    "regions": [
+      "us",
+      "eu"
+    ],
+    "requires": [],
+    "production": {
+      "base_url": "https://myaddon.com/heroku/resources",
+      "sso_url": "https://myaddon.com/sso/login"
+    },
+    "test": {
+      "base_url": "http://localhost:4567/heroku/resources",
+      "sso_url": "http://localhost:4567/sso/login"
+    },
+    "version": "3"
+  },
+  "name": "MyAddon"
+}`
+
+  const mock: any = (filename: any, manifest: any, callback: any) => {
+    mock.filename = filename
+    mock.manifest = manifest
+    callback()
+  }
+
+  generateTest
+    .stdout()
+    .stub(fs, 'writeFile', mock)
+    .stub(inquirer, 'prompt', promptGenerateFalse)
+    .command(['addons:admin:manifest:generate'])
+    .it('runs', ctx => {
+      expect(mock.filename).to.eq('addon_manifest.json')
+      expect(mock.manifest).to.eq(defaultManifest)
+      expect(ctx.stdout).to.contain('The file addon_manifest.json has been saved!')
+    })
+
+  const promptGenerateTrue = sinon.stub()
+  promptGenerateTrue.returns(Promise.resolve({
+    toGenerate: true,
+    toWrite: true
+  }))
+
+  const generatedManifest = `{
+  "id": "myaddon",
+  "api": {
+    "config_vars_prefix": "MYADDON",
+    "config_vars": [
+      "MYADDON_URL"
+    ],
+    "password": "a",
+    "sso_salt": "b",
+    "regions": [
+      "us",
+      "eu"
+    ],
+    "requires": [],
+    "production": {
+      "base_url": "https://myaddon.com/heroku/resources",
+      "sso_url": "https://myaddon.com/sso/login"
+    },
+    "test": {
+      "base_url": "http://localhost:4567/heroku/resources",
+      "sso_url": "http://localhost:4567/sso/login"
+    },
+    "version": "3"
+  },
+  "name": "MyAddon"
+}`
+
+  const randomMock = sinon.stub()
+    .onCall(0).returns('a')
+    .onCall(1).returns('b')
+
+  generateTest
+    .stdout()
+    .stub(fs, 'writeFile', mock)
+    .stub(inquirer, 'prompt', promptGenerateTrue)
+    .stub(randomstring, 'generate', randomMock)
+    .command(['addons:admin:manifest:generate'])
+    .it('runs', ctx => {
+      expect(mock.filename).to.eq('addon_manifest.json')
+      expect(mock.manifest).to.eq(generatedManifest)
+      expect(ctx.stdout).to.contain('The file addon_manifest.json has been saved!')
+    })
+
+  const promptGenerateOptions = sinon.stub()
+  promptGenerateOptions.returns(Promise.resolve({
+    id: 'slug',
+    name: 'name',
+    regions: ['us', 'eu', 'dublin'],
+    toGenerate: false,
+    toWrite: true
+  }))
+
+  const optionsManifest = `{
+  "id": "slug",
+  "api": {
+    "config_vars_prefix": "SLUG",
+    "config_vars": [
+      "SLUG_URL"
+    ],
+    "password": "CHANGEME",
+    "sso_salt": "CHANGEME",
+    "regions": [
+      "us",
+      "eu",
+      "dublin"
+    ],
+    "requires": [],
+    "production": {
+      "base_url": "https://myaddon.com/heroku/resources",
+      "sso_url": "https://myaddon.com/sso/login"
+    },
+    "test": {
+      "base_url": "http://localhost:4567/heroku/resources",
+      "sso_url": "http://localhost:4567/sso/login"
+    },
+    "version": "3"
+  },
+  "name": "name"
+}`
+
+  generateTest
+    .stdout()
+    .stub(fs, 'writeFile', mock)
+    .stub(inquirer, 'prompt', promptGenerateOptions)
+    .command(['addons:admin:manifest:generate'])
+    .it('runs', () => {
+      expect(mock.filename).to.eq('addon_manifest.json')
+      expect(mock.manifest).to.eq(optionsManifest)
     })
 })

--- a/test/commands/addons/admin/open.test.ts
+++ b/test/commands/addons/admin/open.test.ts
@@ -1,9 +1,30 @@
-import {test} from '@oclif/test'
+import {expect} from '@oclif/test'
+
+import cli from 'cli-ux'
+import * as sinon from 'sinon'
+
+import {test} from '../../../utils/test'
 
 describe('addons:admin:open', () => {
+  const openArg = sinon.stub()
+  openArg.throws('not stubbed')
+  openArg.withArgs('https://addons-next.heroku.com/addons/arg-slug').returns(undefined)
+
   test
-    .stdout()
-    .it('runs hello', _ => {
-      true
+    .stub(cli, 'open', () => openArg)
+    .command(['addons:admin:open', 'arg-slug'])
+    .it('opens slug in args', () => {
+      expect(openArg.called).to.eq(true)
+    })
+
+  const openManifest = sinon.stub()
+  openManifest.throws('not stubbed')
+  openManifest.withArgs('https://addons-next.heroku.com/addons/testing-123').returns(undefined)
+
+  test
+    .stub(cli, 'open', () => openManifest)
+    .command(['addons:admin:open'])
+    .it('opens slug in args', () => {
+      expect(openManifest.called).to.eq(true)
     })
 })

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -2,16 +2,9 @@ import {expect} from '@oclif/test'
 import * as fs from 'fs-extra'
 import * as sinon from 'sinon'
 
-import {GenerateManifest, LogManifest, ReadManifest, WriteManifest} from '../src/manifest'
+import {LogManifest, ReadManifest, WriteManifest} from '../src/manifest'
 
 import {manifest, test} from './utils/test'
-
-describe('GenerateManifest', () => {
-  test
-    .it('.run', () => {
-      expect(GenerateManifest.run()).to.be.a('object')
-    })
-})
 
 const manifestMissingSlug = sinon.stub()
 manifestMissingSlug.withArgs('addon_manifest.json').returns(JSON.stringify({}))


### PR DESCRIPTION
@RasPhilCo I am working a larger refactor and found that both generate and open were not tested properly and wanted to beef up the test suite to stop myself from breaking things first.  I went ahead and split up the `run` method in generate while I was in here because it was large & complex.