### PR TITLE
Explicitly require @oclif/config in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @heroku-cli/plugin-addons-admin
 $ heroku COMMAND
 running command...
 $ heroku (-v|--version|version)
-@heroku-cli/plugin-addons-admin/2.0.1 linux-x64 node-v11.1.0
+@heroku-cli/plugin-addons-admin/2.0.2 linux-x64 node-v11.1.0
 $ heroku --help [COMMAND]
 USAGE
   $ heroku COMMAND
@@ -60,7 +60,7 @@ USAGE
   $ heroku addons:admin:manifest:diff
 ```
 
-_See code: [src/commands/addons/admin/manifest/diff.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.1/src/commands/addons/admin/manifest/diff.ts)_
+_See code: [src/commands/addons/admin/manifest/diff.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.2/src/commands/addons/admin/manifest/diff.ts)_
 
 ## `heroku addons:admin:manifest:generate`
 
@@ -79,7 +79,7 @@ EXAMPLE
   The file has been saved!
 ```
 
-_See code: [src/commands/addons/admin/manifest/generate.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.1/src/commands/addons/admin/manifest/generate.ts)_
+_See code: [src/commands/addons/admin/manifest/generate.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.2/src/commands/addons/admin/manifest/generate.ts)_
 
 ## `heroku addons:admin:manifest:pull [SLUG]`
 
@@ -99,7 +99,7 @@ EXAMPLE
     Updating addon_manifest.json... done
 ```
 
-_See code: [src/commands/addons/admin/manifest/pull.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.1/src/commands/addons/admin/manifest/pull.ts)_
+_See code: [src/commands/addons/admin/manifest/pull.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.2/src/commands/addons/admin/manifest/pull.ts)_
 
 ## `heroku addons:admin:manifest:push`
 
@@ -116,7 +116,7 @@ EXAMPLE
     Updating addon_manifest.json... done
 ```
 
-_See code: [src/commands/addons/admin/manifest/push.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.1/src/commands/addons/admin/manifest/push.ts)_
+_See code: [src/commands/addons/admin/manifest/push.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.2/src/commands/addons/admin/manifest/push.ts)_
 
 ## `heroku addons:admin:manifests [SLUG]`
 
@@ -127,7 +127,7 @@ USAGE
   $ heroku addons:admin:manifests [SLUG]
 ```
 
-_See code: [src/commands/addons/admin/manifests.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.1/src/commands/addons/admin/manifests.ts)_
+_See code: [src/commands/addons/admin/manifests.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.2/src/commands/addons/admin/manifests.ts)_
 
 ## `heroku addons:admin:manifests:info [SLUG]`
 
@@ -141,7 +141,7 @@ OPTIONS
   -m, --manifest=manifest  (required) manifest history id
 ```
 
-_See code: [src/commands/addons/admin/manifests/info.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.1/src/commands/addons/admin/manifests/info.ts)_
+_See code: [src/commands/addons/admin/manifests/info.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.2/src/commands/addons/admin/manifests/info.ts)_
 
 ## `heroku addons:admin:open [SLUG]`
 
@@ -160,5 +160,5 @@ EXAMPLE
   Opening https://addons-next.heroku.com/addons/testing-123... done
 ```
 
-_See code: [src/commands/addons/admin/open.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.1/src/commands/addons/admin/open.ts)_
+_See code: [src/commands/addons/admin/open.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.0.2/src/commands/addons/admin/open.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@heroku-cli/command": "^8.1.26",
     "@heroku-cli/schema": "^1.0.3",
     "@oclif/command": "^1.5.4",
+    "@oclif/config": "^1.8.8",
     "@types/fs-extra": "^5.0.4",
     "cli-ux": "^4.7.3",
     "diff": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku-cli/plugin-addons-admin",
   "description": "Heroku CLI plugin to help Heroku add-on providers integrate their services with Heroku.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Aman Ibrahim @amanmibra",
   "bugs": "https://github.com/heroku/heroku-cli-addons-admin/issues",
   "dependencies": {


### PR DESCRIPTION
Adding `@oclif/config` in addition to `@oclif/command` (was going to order but was unsure what you consider the proper ordering with the `@` symbol)