### PR TITLE
Use addon-manifest by default w/ _ warn

### DIFF
--- a/src/commands/addons/admin/manifest/pull.ts
+++ b/src/commands/addons/admin/manifest/pull.ts
@@ -9,7 +9,7 @@ export default class Pull extends Command {
     `$ heroku addons:admin:manifest:pull testing-123
  ...
  Fetching add-on manifest for testing-123... done
- Updating addon_manifest.json... done`,
+ Updating addon-manifest.json... done`,
   ]
 
   static args = [{name: 'slug', description: 'slug name of add-on'}]

--- a/src/commands/addons/admin/manifest/push.ts
+++ b/src/commands/addons/admin/manifest/push.ts
@@ -9,7 +9,7 @@ export default class Push extends Command {
     `$ heroku addons:admin:manifest:push
  ...
  Pushing manifest... done
- Updating addon_manifest.json... done`,
+ Updating addon-manifest.json... done`,
   ]
 
   async run() {

--- a/src/commands/addons/admin/open.ts
+++ b/src/commands/addons/admin/open.ts
@@ -10,7 +10,7 @@ export default class Open extends Command {
 
   static examples = [
     `$ heroku addons:admin:open
-Checking addon_manifest.json... done
+Checking addon-manifest.json... done
 Opening https://addons-next.heroku.com/addons/testing-123... done`,
   ]
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -50,12 +50,24 @@ export abstract class Manifest {
 }
 
 export class ManifestLocal extends Manifest {
+  _filename: string
+
+  constructor() {
+    super()
+    if (fs.existsSync('addon_manifest.json')) {
+      cli.warn('Using addon_manifest.json was a bug, please rename to addon-manifest.json')
+      this._filename = 'addon_manifest.json'
+    } else {
+      this._filename = 'addon-manifest.json'
+    }
+  }
+
   async _get(): Promise<ManifestInterface> {
     let manifest
     try {
-      manifest = fs.readFileSync('addon_manifest.json', 'utf8')
+      manifest = fs.readFileSync(this.filename(), 'utf8')
     } catch (err) {
-      throw new Error(`Check if addon_manifest.json exists in root. \n ${err}`)
+      throw new Error(`Check if ${this.filename()} exists in root. \n ${err}`)
     }
 
     if (!manifest) {
@@ -66,14 +78,18 @@ export class ManifestLocal extends Manifest {
   }
 
   async _set(manifest: ManifestInterface): Promise<ManifestInterface> {
-    cli.action.start(`Updating ${color.blue('addon_manifest.json')}`)
-    fs.writeFileSync('addon_manifest.json', JSON.stringify(manifest, null, 2))
+    cli.action.start(`Updating ${color.blue(this.filename())}`)
+    fs.writeFileSync(this.filename(), JSON.stringify(manifest, null, 2))
     cli.action.stop()
     return manifest
   }
 
   async log(): Promise<void> {
     cli.log(color.bold(JSON.stringify(await this.get(), null, 1)))
+  }
+
+  filename(): string {
+    return this._filename
   }
 }
 

--- a/test/addon.test.ts
+++ b/test/addon.test.ts
@@ -8,7 +8,7 @@ import Addon from '../src/addon'
 import {host, test} from './utils/test'
 
 const manifestMissingSlug = sinon.stub()
-manifestMissingSlug.withArgs('addon_manifest.json').returns(JSON.stringify({}))
+manifestMissingSlug.withArgs('addon-manifest.json').returns(JSON.stringify({}))
 
 const addon = (slug?: string) => {
   return new Addon({} as IConfig, slug)

--- a/test/commands/addons/admin/manifest/generate.test.ts
+++ b/test/commands/addons/admin/manifest/generate.test.ts
@@ -9,7 +9,7 @@ import {manifest} from '../../../../utils/test'
 describe('addons:admin:manifest:generate', () => {
   const fsWriteFileSync = sinon.stub()
   fsWriteFileSync.throws('write not stubbed')
-  fsWriteFileSync.withArgs('addon_manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
+  fsWriteFileSync.withArgs('addon-manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
 
   const fsWriteFileNotCalled = sinon.stub()
   fsWriteFileNotCalled.throws('write not stubbed')
@@ -34,7 +34,7 @@ describe('addons:admin:manifest:generate', () => {
     .command(['addons:admin:manifest:generate'])
     .catch(() => {})
     .it('runs', ctx => {
-      expect(ctx.stdout).to.contain('addon_manifest.json will not be created. Have a good day!')
+      expect(ctx.stdout).to.contain('addon-manifest.json will not be created. Have a good day!')
     })
 
   const promptGenerateFalse = sinon.stub()
@@ -82,9 +82,9 @@ describe('addons:admin:manifest:generate', () => {
     .stub(inquirer, 'prompt', promptGenerateFalse)
     .command(['addons:admin:manifest:generate'])
     .it('runs', ctx => {
-      expect(mock.filename).to.eq('addon_manifest.json')
+      expect(mock.filename).to.eq('addon-manifest.json')
       expect(mock.manifest).to.eq(defaultManifest)
-      expect(ctx.stdout).to.contain('The file addon_manifest.json has been saved!')
+      expect(ctx.stdout).to.contain('The file addon-manifest.json has been saved!')
     })
 
   const promptGenerateTrue = sinon.stub()
@@ -131,9 +131,9 @@ describe('addons:admin:manifest:generate', () => {
     .stub(randomstring, 'generate', randomMock)
     .command(['addons:admin:manifest:generate'])
     .it('runs', ctx => {
-      expect(mock.filename).to.eq('addon_manifest.json')
+      expect(mock.filename).to.eq('addon-manifest.json')
       expect(mock.manifest).to.eq(generatedManifest)
-      expect(ctx.stdout).to.contain('The file addon_manifest.json has been saved!')
+      expect(ctx.stdout).to.contain('The file addon-manifest.json has been saved!')
     })
 
   const promptGenerateOptions = sinon.stub()
@@ -179,7 +179,7 @@ describe('addons:admin:manifest:generate', () => {
     .stub(inquirer, 'prompt', promptGenerateOptions)
     .command(['addons:admin:manifest:generate'])
     .it('runs', () => {
-      expect(mock.filename).to.eq('addon_manifest.json')
+      expect(mock.filename).to.eq('addon-manifest.json')
       expect(mock.manifest).to.eq(optionsManifest)
     })
 })

--- a/test/commands/addons/admin/manifest/pull.test.ts
+++ b/test/commands/addons/admin/manifest/pull.test.ts
@@ -42,7 +42,7 @@ describe('addons:admin:manifest:pull', () => {
 
   const fsWriteFileSync = sinon.stub()
   fsWriteFileSync.throws('write not stubbed')
-  fsWriteFileSync.withArgs('addon_manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
+  fsWriteFileSync.withArgs('addon-manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
 
   pullTest
     .stub(fs, 'writeFileSync', fsWriteFileSync)

--- a/test/commands/addons/admin/manifest/push.test.ts
+++ b/test/commands/addons/admin/manifest/push.test.ts
@@ -38,7 +38,7 @@ describe('addons:admin:manifest:push', () => {
 
   const fsWriteFileSync = sinon.stub()
   fsWriteFileSync.throws('write not stubbed')
-  fsWriteFileSync.withArgs('addon_manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
+  fsWriteFileSync.withArgs('addon-manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
 
   pushTest
     .stub(fs, 'writeFileSync', fsWriteFileSync)

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -8,27 +8,46 @@ import {ManifestInterface, ManifestLocal} from '../src/manifest'
 
 import {host, manifest, test} from './utils/test'
 
-describe('ManifestLocal', () => {
-  test
-    .it('.get', async () => {
+const underExists = sinon.stub()
+underExists.throws('not stubbed')
+underExists.withArgs('addon-manifest.json').returns(false)
+underExists.withArgs('addon_manifest.json').returns(true)
+
+describe('ManifestLocal (addon_manifest.json)', () => {
+  const writeManifest = {id: 'slug'} as ManifestInterface
+
+  const fsWriteFileSync = sinon.stub()
+  fsWriteFileSync.throws('write not stubbed')
+  fsWriteFileSync.withArgs('addon_manifest.json', JSON.stringify(writeManifest, null, 2)).returns(undefined)
+  fsWriteFileSync.withArgs('addon_manifest.json', JSON.stringify(manifest, null, 2)).returns(undefined)
+
+  const fsReadFileSync = sinon.stub()
+  fsReadFileSync.throws('read not stubbed')
+  fsReadFileSync.withArgs('addon_manifest.json').returns(JSON.stringify(manifest))
+
+  const underTest = test
+    .stub(fs, 'readFileSync', fsReadFileSync)
+    .stub(fs, 'writeFileSync', fsWriteFileSync)
+    .stub(fs, 'existsSync', underExists)
+    .stub(fs, 'existsSync', underExists)
+
+  underTest
+    .stderr()
+    .it('.get', async ctx => {
       const localManifest = new ManifestLocal()
       expect(await localManifest.get()).to.be.a('object')
       expect(await localManifest.get()).to.deep.equal(manifest)
+      expect(ctx.stderr).to.contain('Using addon_manifest.json was a bug, please rename to addon-manifest.json')
     })
-  test
+
+  underTest
     .it('.get caching', async () => {
       const localManifest = new ManifestLocal()
       const manifestGet = await localManifest.get()
       expect(await localManifest.get()).to.equal(manifestGet)
     })
 
-  const writeManifest = {id: 'slug'} as ManifestInterface
-
-  const fsWriteFileSync = sinon.stub()
-  fsWriteFileSync.throws('write not stubbed')
-  fsWriteFileSync.withArgs('addon_manifest.json', JSON.stringify(writeManifest, null, 2)).returns(undefined)
-
-  test
+  underTest
     .stub(fs, 'writeFileSync', fsWriteFileSync)
     .it('.set', async () => {
       const localManifest = new ManifestLocal()
@@ -37,7 +56,7 @@ describe('ManifestLocal', () => {
       expect(await localManifest.get()).to.equal(writeManifest)
     })
 
-  test
+  underTest
     .stdout()
     .it('.log', async ctx => {
       const localManifest = new ManifestLocal()
@@ -70,6 +89,168 @@ describe('ManifestLocal', () => {
  }
 }
 `)
+    })
+
+  underTest
+    .it('.filename', async () => {
+      expect(new ManifestLocal().filename()).to.eq('addon_manifest.json')
+    })
+})
+
+const dashExists = sinon.stub()
+dashExists.throws('not stubbed')
+dashExists.withArgs('addon_manifest.json').returns(false)
+dashExists.withArgs('addon-manifest.json').returns(true)
+
+describe('ManifestLocal (addon-manifest.json)', () => {
+  const dashTest = test
+    .stub(fs, 'existsSync', dashExists)
+
+  dashTest
+    .it('.get', async () => {
+      const localManifest = new ManifestLocal()
+      expect(await localManifest.get()).to.be.a('object')
+      expect(await localManifest.get()).to.deep.equal(manifest)
+    })
+  dashTest
+    .it('.get caching', async () => {
+      const localManifest = new ManifestLocal()
+      const manifestGet = await localManifest.get()
+      expect(await localManifest.get()).to.equal(manifestGet)
+    })
+
+  const writeManifest = {id: 'slug'} as ManifestInterface
+
+  const fsWriteFileSync = sinon.stub()
+  fsWriteFileSync.throws('write not stubbed')
+  fsWriteFileSync.withArgs('addon-manifest.json', JSON.stringify(writeManifest, null, 2)).returns(undefined)
+
+  dashTest
+    .stub(fs, 'writeFileSync', fsWriteFileSync)
+    .it('.set', async () => {
+      const localManifest = new ManifestLocal()
+      expect(await localManifest.set(writeManifest)).to.equal(writeManifest)
+      expect(fsWriteFileSync.called).to.eq(true)
+      expect(await localManifest.get()).to.equal(writeManifest)
+    })
+
+  dashTest
+    .stdout()
+    .it('.log', async ctx => {
+      const localManifest = new ManifestLocal()
+      await localManifest.set(manifest)
+      expect(await localManifest.log()).to.be.a('undefined')
+      expect(ctx.stdout).to.deep.equal(`{
+ "id": "testing-123",
+ "name": "MyAddon",
+ "api": {
+  "config_vars_prefix": "MYADDON",
+  "config_vars": [
+   "MYADDON_URL"
+  ],
+  "password": "bv95AM7726CwVQ7cHUSKuOb3tTREDdVn",
+  "sso_salt": "KtdFl80yzJvkEvq7bmJuQkuXKtV2nx6T",
+  "regions": [
+   "us",
+   "eu"
+  ],
+  "requires": [],
+  "production": {
+   "base_url": "https://myaddon.com/heroku/resources",
+   "sso_url": "https://myaddon.com/sso/login"
+  },
+  "test": {
+   "base_url": "http://localhost:4567/heroku/resources",
+   "sso_url": "http://localhost:4567/sso/login"
+  },
+  "version": "3"
+ }
+}
+`)
+    })
+
+  dashTest
+    .it('.filename', async () => {
+      expect(new ManifestLocal().filename()).to.eq('addon-manifest.json')
+    })
+})
+
+const noneExist = sinon.stub()
+noneExist.throws('not stubbed')
+noneExist.withArgs('addon_manifest.json').returns(false)
+noneExist.withArgs('addon-manifest.json').returns(false)
+
+describe('ManifestLocal (null)', () => {
+  const noneTest = test
+    .stub(fs, 'existsSync', dashExists)
+
+  noneTest
+    .it('.get', async () => {
+      const localManifest = new ManifestLocal()
+      expect(await localManifest.get()).to.be.a('object')
+      expect(await localManifest.get()).to.deep.equal(manifest)
+    })
+
+  noneTest
+    .it('.get caching', async () => {
+      const localManifest = new ManifestLocal()
+      const manifestGet = await localManifest.get()
+      expect(await localManifest.get()).to.equal(manifestGet)
+    })
+
+  const writeManifest = {id: 'slug'} as ManifestInterface
+
+  const fsWriteFileSync = sinon.stub()
+  fsWriteFileSync.throws('write not stubbed')
+  fsWriteFileSync.withArgs('addon-manifest.json', JSON.stringify(writeManifest, null, 2)).returns(undefined)
+
+  noneTest
+    .stub(fs, 'writeFileSync', fsWriteFileSync)
+    .it('.set', async () => {
+      const localManifest = new ManifestLocal()
+      expect(await localManifest.set(writeManifest)).to.equal(writeManifest)
+      expect(fsWriteFileSync.called).to.eq(true)
+      expect(await localManifest.get()).to.equal(writeManifest)
+    })
+
+  noneTest
+    .stdout()
+    .it('.log', async ctx => {
+      const localManifest = new ManifestLocal()
+      await localManifest.set(manifest)
+      expect(await localManifest.log()).to.be.a('undefined')
+      expect(ctx.stdout).to.deep.equal(`{
+ "id": "testing-123",
+ "name": "MyAddon",
+ "api": {
+  "config_vars_prefix": "MYADDON",
+  "config_vars": [
+   "MYADDON_URL"
+  ],
+  "password": "bv95AM7726CwVQ7cHUSKuOb3tTREDdVn",
+  "sso_salt": "KtdFl80yzJvkEvq7bmJuQkuXKtV2nx6T",
+  "regions": [
+   "us",
+   "eu"
+  ],
+  "requires": [],
+  "production": {
+   "base_url": "https://myaddon.com/heroku/resources",
+   "sso_url": "https://myaddon.com/sso/login"
+  },
+  "test": {
+   "base_url": "http://localhost:4567/heroku/resources",
+   "sso_url": "http://localhost:4567/sso/login"
+  },
+  "version": "3"
+ }
+}
+`)
+    })
+
+  noneTest
+    .it('.filename', async () => {
+      expect(new ManifestLocal().filename()).to.eq('addon-manifest.json')
     })
 })
 

--- a/test/utils/test.ts
+++ b/test/utils/test.ts
@@ -7,11 +7,11 @@ const manifest = require('./../fixture/addon_manifest')
 
 const fsReadFileSync = sinon.stub()
 fsReadFileSync.throws('read not stubbed')
-fsReadFileSync.withArgs('addon_manifest.json').returns(JSON.stringify(manifest))
+fsReadFileSync.withArgs('addon-manifest.json').returns(JSON.stringify(manifest))
 
 const fsWriteFileSync = sinon.stub()
 fsWriteFileSync.throws('write not stubbed')
-fsWriteFileSync.withArgs('addon_manifest.json').returns(undefined)
+fsWriteFileSync.withArgs('addon-manifest.json').returns(undefined)
 
 const test = oTest
 .stub(fs, 'readFileSync', fsReadFileSync)


### PR DESCRIPTION
@RasPhilCo @mathias could you review?  This fixes the bug referenced in https://github.com/heroku/heroku-cli-addons-admin/issues/28 where `addon_manifest.json` was created rather than `addon-manifest.js`.  For people who have already used this plugin and have a `addon_manifest.json` it will continue to function but warn them that they should rename to `addon-manifest.json`.  New installs of this plugin will use `addon-manifest.json` which should hopefully reduce confusion in the future.