### PR TITLE
Fix args parsing to diff & push

### DIFF
--- a/src/commands/addons/admin/manifest/diff.ts
+++ b/src/commands/addons/admin/manifest/diff.ts
@@ -8,6 +8,8 @@ export default class Diff extends Command {
   static description = 'compares remote manifest to local manifest and finds differences'
 
   async run() {
+    this.parse(Diff)
+
     const addon = new Addon(this.config)
 
     // reading current manifest

--- a/src/commands/addons/admin/manifest/push.ts
+++ b/src/commands/addons/admin/manifest/push.ts
@@ -13,6 +13,8 @@ export default class Push extends Command {
   ]
 
   async run() {
+    this.parse(Push)
+
     const addon = new Addon(this.config)
     const manifest = addon.local()
 


### PR DESCRIPTION
I passed an arg to push on accident and it did not error, calling parse in diff & push to validate that no args were passed to the commands