### PR TITLE
Replace dash with underscore in manifest:generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @heroku-cli/plugin-addons-admin
 $ heroku COMMAND
 running command...
 $ heroku (-v|--version|version)
-@heroku-cli/plugin-addons-admin/2.2.0 linux-x64 node-v11.1.0
+@heroku-cli/plugin-addons-admin/2.2.1 linux-x64 node-v11.1.0
 $ heroku --help [COMMAND]
 USAGE
   $ heroku COMMAND
@@ -60,7 +60,7 @@ USAGE
   $ heroku addons:admin:manifest:diff
 ```
 
-_See code: [src/commands/addons/admin/manifest/diff.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.0/src/commands/addons/admin/manifest/diff.ts)_
+_See code: [src/commands/addons/admin/manifest/diff.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.1/src/commands/addons/admin/manifest/diff.ts)_
 
 ## `heroku addons:admin:manifest:generate`
 
@@ -79,7 +79,7 @@ EXAMPLE
   The file has been saved!
 ```
 
-_See code: [src/commands/addons/admin/manifest/generate.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.0/src/commands/addons/admin/manifest/generate.ts)_
+_See code: [src/commands/addons/admin/manifest/generate.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.1/src/commands/addons/admin/manifest/generate.ts)_
 
 ## `heroku addons:admin:manifest:pull [SLUG]`
 
@@ -99,7 +99,7 @@ EXAMPLE
     Updating addon-manifest.json... done
 ```
 
-_See code: [src/commands/addons/admin/manifest/pull.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.0/src/commands/addons/admin/manifest/pull.ts)_
+_See code: [src/commands/addons/admin/manifest/pull.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.1/src/commands/addons/admin/manifest/pull.ts)_
 
 ## `heroku addons:admin:manifest:push`
 
@@ -116,7 +116,7 @@ EXAMPLE
     Updating addon-manifest.json... done
 ```
 
-_See code: [src/commands/addons/admin/manifest/push.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.0/src/commands/addons/admin/manifest/push.ts)_
+_See code: [src/commands/addons/admin/manifest/push.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.1/src/commands/addons/admin/manifest/push.ts)_
 
 ## `heroku addons:admin:manifests [SLUG]`
 
@@ -127,7 +127,7 @@ USAGE
   $ heroku addons:admin:manifests [SLUG]
 ```
 
-_See code: [src/commands/addons/admin/manifests.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.0/src/commands/addons/admin/manifests.ts)_
+_See code: [src/commands/addons/admin/manifests.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.1/src/commands/addons/admin/manifests.ts)_
 
 ## `heroku addons:admin:manifests:info [SLUG]`
 
@@ -141,7 +141,7 @@ OPTIONS
   -m, --manifest=manifest  (required) manifest history id
 ```
 
-_See code: [src/commands/addons/admin/manifests/info.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.0/src/commands/addons/admin/manifests/info.ts)_
+_See code: [src/commands/addons/admin/manifests/info.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.1/src/commands/addons/admin/manifests/info.ts)_
 
 ## `heroku addons:admin:open [SLUG]`
 
@@ -160,5 +160,5 @@ EXAMPLE
   Opening https://addons-next.heroku.com/addons/testing-123... done
 ```
 
-_See code: [src/commands/addons/admin/open.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.0/src/commands/addons/admin/open.ts)_
+_See code: [src/commands/addons/admin/open.ts](https://github.com/heroku/heroku-cli-addons-admin/blob/v2.2.1/src/commands/addons/admin/open.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku-cli/plugin-addons-admin",
   "description": "Heroku CLI plugin to help Heroku add-on providers integrate their services with Heroku.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Aman Ibrahim @amanmibra",
   "bugs": "https://github.com/heroku/heroku-cli-addons-admin/issues",
   "dependencies": {

--- a/src/commands/addons/admin/manifest/generate.ts
+++ b/src/commands/addons/admin/manifest/generate.ts
@@ -162,7 +162,7 @@ The file has been saved!`,
       name: 'MyAddon',
     }
 
-    let configVarsPrefix = data.id ? data.id.toUpperCase().replace(/-/g, '_') : null
+    let configVarsPrefix = data.id && data.id.toUpperCase().replace(/-/g, '_')
 
     manifest.id = data.id || manifest.id
     manifest.api.config_vars_prefix = (configVarsPrefix ? configVarsPrefix : manifest.api.config_vars_prefix)

--- a/src/commands/addons/admin/manifest/generate.ts
+++ b/src/commands/addons/admin/manifest/generate.ts
@@ -162,9 +162,11 @@ The file has been saved!`,
       name: 'MyAddon',
     }
 
+    let configVarsPrefix = data.id ? data.id.toUpperCase().replace(/-/g, '_') : null
+
     manifest.id = data.id || manifest.id
-    manifest.api.config_vars_prefix = (data.id ? data.id.toUpperCase() : manifest.api.config_vars_prefix)
-    manifest.api.config_vars = (data.id ? [`${data.id.toUpperCase()}_URL`] : manifest.api.config_vars)
+    manifest.api.config_vars_prefix = (configVarsPrefix ? configVarsPrefix : manifest.api.config_vars_prefix)
+    manifest.api.config_vars = (configVarsPrefix ? [`${configVarsPrefix}_URL`] : manifest.api.config_vars)
     manifest.api.password = data.password || manifest.api.password
     manifest.api.sso_salt = data.sso_salt || manifest.api.sso_salt
     manifest.api.regions = data.regions || manifest.api.regions

--- a/test/commands/addons/admin/manifest/generate.test.ts
+++ b/test/commands/addons/admin/manifest/generate.test.ts
@@ -170,4 +170,44 @@ describe('addons:admin:manifest:generate', () => {
       expect(mock.filename).to.eq('addon-manifest.json')
       expect(mock.manifest).to.eq(optionsManifest)
     })
+
+  const promptGenerateDashOptions = sinon.stub()
+  promptGenerateDashOptions.returns(Promise.resolve({
+    id: 'slug-with-dash',
+    name: 'name',
+    regions: ['us'],
+    toGenerate: false,
+    toWrite: true
+  }))
+
+  const optionsDashManifest = `{
+  "id": "slug-with-dash",
+  "api": {
+    "config_vars_prefix": "SLUG_WITH_DASH",
+    "config_vars": [
+      "SLUG_WITH_DASH_URL"
+    ],
+    "password": "CHANGEME",
+    "sso_salt": "CHANGEME",
+    "regions": [
+      "us"
+    ],
+    "requires": [],
+    "production": {
+      "base_url": "https://myaddon.com/heroku/resources",
+      "sso_url": "https://myaddon.com/sso/login"
+    },
+    "version": "3"
+  },
+  "name": "name"
+}`
+
+  generateTest
+    .stdout()
+    .stub(fs, 'writeFile', mock)
+    .stub(inquirer, 'prompt', promptGenerateDashOptions)
+    .command(['addons:admin:manifest:generate'])
+    .it('runs', () => {
+      expect(mock.manifest).to.eq(optionsDashManifest)
+    })
 })


### PR DESCRIPTION
Dashes are not valid in `config_vars_prefix` so translate when in slugs to generate valid config vars.