### PR TITLE
Revert isNaN logic to fix bug

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,7 @@
     "node/no-missing-import": "off",
     "unicorn/no-array-for-each": "off",
     "unicorn/no-useless-undefined": "warn",
-    "unicorn/prefer-node-protocol": "warn"
-    
+    "unicorn/prefer-node-protocol": "warn",
+    "unicorn/prefer-number-properties": "warn"
   }
 }

--- a/src/commands/addons/admin/manifest/generate.ts
+++ b/src/commands/addons/admin/manifest/generate.ts
@@ -49,7 +49,7 @@ The file has been saved!`,
       message: 'Enter slugname/manifest id:',
       default: flags.slug,
       validate: (input: any): boolean => {
-        if (input.trim() === '' || !Number.isNaN(input)) {
+        if (input.trim() === '' || !isNaN(input)) {
           this.error('Please use a string as a slug name.')
           return false
         }


### PR DESCRIPTION
Changing to `Number.isNaN` introduced a bug due to a subtle difference between `Number.isNaN` and `isNaN` where `Number.isNaN` will return false for a string with just letters, which defeats the intended purpose of this logic.