### PR TITLE
Respect `HEROKU_HOST`

### DIFF
--- a/src/addon-client.ts
+++ b/src/addon-client.ts
@@ -17,7 +17,8 @@ export default class AddonClient {
   constructor(config: any) {
     const client = new APIClient(config, {})
     const host = process.env.HEROKU_ADDONS_HOST
-    client.defaults.host = host ? url.parse(host).host : 'addons.heroku.com'
+    const herokuHost = process.env.HEROKU_HOST || 'heroku.com'
+    client.defaults.host = host ? url.parse(host).host : `addons.${herokuHost}`
 
     this.client = client
   }

--- a/src/commands/addons/admin/open.ts
+++ b/src/commands/addons/admin/open.ts
@@ -11,7 +11,7 @@ export default class Open extends Command {
   static examples = [
     `$ heroku addons:admin:open
 Checking addon-manifest.json... done
-Opening https://addons-next.heroku.com/addons/testing-123... done`,
+Opening https://addons-next.${process.env.HEROKU_HOST || 'heroku.com'}/addons/testing-123... done`,
   ]
 
   async run() {
@@ -19,7 +19,8 @@ Opening https://addons-next.heroku.com/addons/testing-123... done`,
 
     const addon = new Addon(this.config, args.slug)
     const slug = await addon.slug()
-    const url = `https://addons-next.heroku.com/addons/${slug}`
+    const herokuHost = process.env.HEROKU_HOST || 'heroku.com'
+    const url = `https://addons-next.${herokuHost}/addons/${slug}`
 
     cli.action.start(`Opening ${url}`)
     await cli.open(url)


### PR DESCRIPTION
This change makes the plug-in respect the `HEROKU_HOST` environment variable when constructing default hostnames.

The plug-in already allows setting `HEROKU_ADDONS_HOST` but it doesn't have an equivalent for the partner portal. Relying on `HEROKU_HOST` allows us to support both with an environment variable already in wide use.

The `HEROKU_ADDONS_HOST` stays in place and takes precedence so you can still point to a particular deployment in any environment.